### PR TITLE
Uninstall.php file included and minor changes.

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,11 +1,12 @@
 <?php
-/*
-Plugin Name: Simple Featured post likes
-Description: Adds Likes/Favorites to Wordpress post or custom post type.
-Author: Richard Miles
-Version: 1.0
-Author URI: http://richymiles.wordpress.com
-*/
+/**
+ * Plugin Name: Simple Featured post likes
+ * Description: Adds Likes/Favorites to Wordpress post or custom post type.
+ * Author: Richard Miles
+ * Version: 1.0.1
+ * Author URI: http://richymiles.wordpress.com
+ */
+
 
 function get_users_array($post_id) {
     $new_array = array();

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Simple custom post likes ===
 Contributors: richymilo
-Donate link: http://wobble.co.za/
-Tags: custom post types, likes, featured
-Requires at least: 3.0.1
+Donate link: http://richymiles.wordpress.com
+Tags: custom post types, likes, featured, voting, rating, polling
+Requires at least: 3.9
 Tested up to: 4.1.1
-Stable tag: 4.3
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,9 @@ The element that the box should be appended to as well as the post type to targe
 
 
 == Changelog ==
+= 1.0.1 =
+* Minor Changes
+* Added Uninstall.php to clean up database when uninstalled.
 
 = 1.0 =
 * First Version, Basic Working copy

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Fired when the plugin is uninstalled.
+ *
+ * @link       http://richymiles.wordpress.com
+ * @since      1.0.1
+ *
+ * @package    Simple_custom_post_likes
+ */
+
+// If uninstall not called from WordPress, then exit.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) { exit; }
+
+$option_names = array(
+	'favourates_post_type', 
+	'favourates_element'
+);
+
+if ( is_multisite() ) {
+	$ms_sites = wp_get_sites();
+	if( 0 < sizeof( $ms_sites ) ) {
+		foreach ( $ms_sites as $ms_site ) {
+			switch_to_blog( $ms_site['blog_id'] );
+			if( sizeof( $option_names ) > 0 ) {
+				foreach( $option_names as $option_name ) {
+					delete_option( $option_name );
+					plugin_uninstalled();
+				}
+			}
+		}
+	}
+	restore_current_blog();
+} else {
+	if( sizeof( $option_names ) > 0 ) {
+		foreach( $option_names as $option_name ) {
+			delete_option( $option_name );
+			plugin_uninstalled();
+		}
+	}
+}
+
+/**
+ * Delete plugin meta when uninstalled
+ *
+ * @access public
+ * @return void
+ */
+function plugin_uninstalled() {
+	global $wpdb;
+	$post_meta_names = array( 'favourite_users');
+	if( sizeof( $post_meta_names ) > 0 ) {
+		foreach( $post_meta_names as $post_meta_name ) {
+			$wpdb->query( "DELETE FROM $wpdb->postmeta WHERE meta_key = '$post_meta_name'" );
+		}
+	}
+}


### PR DESCRIPTION
Added a WordPress `uninstall.php` file that will run auto-magically upon plugin deletion. This will simply perform the clean-up task of removing plugin options and post meta that the plugin creates.

Also, some minor readme.txt edits.
